### PR TITLE
fix: remove-dark-mode script leaves dangling & when removing .dark blocks

### DIFF
--- a/scripts/remove-dark-mode.js
+++ b/scripts/remove-dark-mode.js
@@ -190,11 +190,13 @@ function cleanDarkStyles(relativePath) {
   // 4. Remove #dark-mode-toggle blocks
   content = removeCssBlock(content, '#dark-mode-toggle');
 
-  // 5. Remove .dark utility class blocks
-  content = removeCssBlock(content, '.dark');
+  // 5. Remove nested &.dark blocks FIRST (must run before .dark, or the
+  //    .dark removal regex will match the `.dark` part of `&.dark`, strip
+  //    the block, and leave a dangling `&` with no braces — breaking LESS)
+  content = removeCssBlock(content, '&.dark');
 
-  // 6. Remove nested &.dark blocks (e.g. inside other selectors)
-  content = content.replace(/\n?\s*&\.dark\s*\{[^}]*\}/g, '');
+  // 6. Remove .dark utility class blocks (safe now that &.dark is already gone)
+  content = removeCssBlock(content, '.dark');  
 
   // 7. Remove the standalone body transition only used for dark mode color shift
   content = content.replace(


### PR DESCRIPTION
The .dark removal step used removeCssBlock, whose regex (\s*\.dark...\{) could match starting at the . inside &.dark { — since \s* matches zero characters. This stripped the block contents but left a bare & with no braces, breaking LESS parsing.

Fix: run removeCssBlock(content, '&.dark') first, so &.dark blocks are fully gone before the .dark pass runs. Also replaces the previous [^}]* regex for &.dark which couldn't handle nested rules.